### PR TITLE
Transform error messages class to danger

### DIFF
--- a/plonetheme/bootstrap/browser/bootstrap-integration.js
+++ b/plonetheme/bootstrap/browser/bootstrap-integration.js
@@ -178,4 +178,6 @@ $(document).ready(function(){
         window.location = $(this).attr('href');
     });
     */
+    /* Make the portal_messages redish in case of error */
+    $('.alert-error').removeClass('alert-error').addClass('alert-danger');
 });


### PR DESCRIPTION
I had to add this transformation to get the error messages properly styled
```
$('.alert-error').removeClass('alert-error').addClass('alert-danger');
```